### PR TITLE
Error in listener should not fail emitting code.

### DIFF
--- a/src/Emitter.spec.ts
+++ b/src/Emitter.spec.ts
@@ -1,6 +1,6 @@
 import test from 'ava'
 
-import { createActionCreator, Emitter } from './index'
+import { createActionCreator, Emitter, errorAction } from './index'
 
 test('addListener(): listener(payload) is typed', t => {
   const emitter = new Emitter()
@@ -62,4 +62,27 @@ test('emit with meta gets meta in second param', t => {
 
   emitter.emit(count(1, { version: 3 }))
   emitter.emit(count(2, { version: 3 }))
+})
+
+test('listener throws error should not affect code', t => {
+  const emitter = new Emitter()
+  const count = createActionCreator<number>('count')
+
+  function noThrow() {
+    try {
+      emitter.emit(count(1, undefined))
+    }
+    catch {
+      t.fail('should not throw')
+    }
+  }
+
+  emitter.on(count, () => { throw new Error('thrown') })
+
+  emitter.on(errorAction, err => {
+    t.is(err.message, 'thrown')
+  })
+
+  noThrow()
+
 })

--- a/src/Emitter.spec.ts
+++ b/src/Emitter.spec.ts
@@ -64,7 +64,7 @@ test('emit with meta gets meta in second param', t => {
   emitter.emit(count(2, { version: 3 }))
 })
 
-test('listener throws error should not affect code', t => {
+test(`error thwon in listener should not affect emitting code. An error action is emitted to capture the error so it will not be lost.`, t => {
   const emitter = new Emitter()
   const count = createActionCreator<number>('count')
 


### PR DESCRIPTION
Emitting action should be in a fire-and-forget manner.

One usage of `fsa-emitter` is to send rich events to the UI layer.
UI layer will handle the event and update the UI.

Anything crash on the UI should do no harm to the application logic.

https://gist.github.com/unional/68c6a9477b2f128d50c9388a5548a885

Where there is an Error thrown in the listener, an `error` event will be emitted instead.