### PR TITLE
ci: prepare for the cyberuni transfer and go secretless

### DIFF
--- a/.changeset/cyberuni-transfer-metadata.md
+++ b/.changeset/cyberuni-transfer-metadata.md
@@ -1,0 +1,8 @@
+---
+'fsa-emitter': patch
+---
+
+Point `repository`, `homepage` and `bugs` at `cyberuni/fsa-emitter`.
+
+`repository` is read when generating provenance attestations, so it has to be correct
+at publish time — not merely correct in the repo.

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,8 +2,11 @@ name: pull-request
 on:
   pull_request:
     types: [opened, synchronize]
+  merge_group:
 
 jobs:
   code:
-    uses: unional/.github/.github/workflows/pnpm-verify-linux.yml@main
-
+    uses: cyberuni/.github/.github/workflows/pnpm-verify.yml@main
+    with:
+      os: '["ubuntu-latest"]'
+      skip-playwright: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,15 @@ on:
 
 jobs:
   code:
-    uses: unional/.github/.github/workflows/pnpm-verify-linux.yml@main
+    uses: cyberuni/.github/.github/workflows/pnpm-verify.yml@main
+    with:
+      os: '["ubuntu-latest"]'
+      skip-playwright: true
 
   release:
-    uses: unional/.github/.github/workflows/pnpm-release-changeset.yml@main
+    uses: cyberuni/.github/.github/workflows/pnpm-release-changeset-oidc.yml@main
     needs: code
-    secrets: inherit
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 
 [![GitHub NodeJS][github-nodejs]][github-action-url]
 [![Codecov][codecov-image]][codecov-url]
-[![Semantic Release][semantic-release-image]][semantic-release-url]
 [![Visual Studio Code][vscode-image]][vscode-url]
 
 `EventEmitter` in FSA style.
@@ -293,15 +292,13 @@ git push
 ```
 
 [@unional/events-plus]: https://github.com/unional/events-plus
-[codecov-image]: https://codecov.io/gh/unional/fsa-emitter/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/unional/fsa-emitter
+[codecov-image]: https://codecov.io/gh/cyberuni/fsa-emitter/branch/main/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/cyberuni/fsa-emitter
 [downloads-image]: https://img.shields.io/npm/dm/fsa-emitter.svg?style=flat
 [downloads-url]: https://npmjs.org/package/fsa-emitter
-[github-nodejs]: https://github.com/unional/fsa-emitter/workflows/nodejs/badge.svg
-[github-action-url]: https://github.com/unional/fsa-emitter/actions
+[github-nodejs]: https://github.com/cyberuni/fsa-emitter/actions/workflows/release.yml/badge.svg
+[github-action-url]: https://github.com/cyberuni/fsa-emitter/actions
 [npm-image]: https://img.shields.io/npm/v/fsa-emitter.svg?style=flat
 [npm-url]: https://npmjs.org/package/fsa-emitter
-[semantic-release-image]: https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg
-[semantic-release-url]: https://github.com/semantic-release/semantic-release
 [vscode-image]: https://img.shields.io/badge/vscode-ready-green.svg
 [vscode-url]: https://code.visualstudio.com/

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
 		"eventemitter3",
 		"utility"
 	],
-	"homepage": "https://github.com/unional/fsa-emitter",
+	"homepage": "https://github.com/cyberuni/fsa-emitter",
 	"bugs": {
-		"url": "https://github.com/unional/fsa-emitter/issues"
+		"url": "https://github.com/cyberuni/fsa-emitter/issues"
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/unional/fsa-emitter.git"
+		"url": "https://github.com/cyberuni/fsa-emitter.git"
 	},
 	"license": "MIT",
 	"author": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 allowBuilds:
   esbuild: true
   fsevents: true
+  # Added: pnpm 11 turns an unapproved build script into a non-zero exit
+  # (ERR_PNPM_IGNORED_BUILDS), which is what has kept every run red since #209.
+  unrs-resolver: true


### PR DESCRIPTION
Phase A of the OTP batch. **Do not merge yet** — this PR is deliberately written against the world *after* the transfer to `cyberuni`, so landing it before the transfer + `npm trust` registration would point provenance metadata at a repo that does not exist yet and trigger a release that cannot publish, with no `NPM_TOKEN` fallback.

## Why every run has been red

`unrs-resolver` was never approved to run its build script, and **pnpm 11 turns `ERR_PNPM_IGNORED_BUILDS` into a non-zero exit** rather than the warning it used to be. Both `pull-request` and `release` have failed at `pnpm install` since #209 bumped pnpm. Adding it to `allowBuilds` is the whole fix.

Reproduced locally with pnpm 11.20.0, and `pnpm verify` passes end to end after it (9 suites / 51 tests, size-limit and dependency-check clean).

That is a pre-existing break, not something this migration introduced; it just has to be fixed before "green PR" means anything.

## Both jobs move to cyberuni

A repo living in the org should depend on `unional/*` for nothing — reaching into a personal namespace for the `code` job reintroduces the single point of failure the transfer exists to remove.

Not a like-for-like swap: cyberuni names it `pnpm-verify.yml` (not `pnpm-verify-linux.yml`) and its default matrix is 3 OS × 2 Node.

| input | value | why |
|---|---|---|
| `os` | `["ubuntu-latest"]` | pure-TS library, no platform-specific behaviour — otherwise CI cost triples for nothing |
| `skip-playwright` | `true` | jest only, no browser tests |
| `skip-codecov` | *omitted* | the upload feeds the README badge and gates nothing; **never** required as a status context |

The required context is preserved: cyberuni's workflow keeps the same `all-checks` job, so a caller job id of `code` still produces `code / all-checks`.

## Release goes secretless

`pnpm-release-changeset.yml` → `pnpm-release-changeset-oidc.yml`. No `NPM_TOKEN`; publish credentials are minted per run and provenance attestations come for free.

`secrets: inherit` is replaced by an explicit `permissions:` block on the release job. That is least privilege, and it is what lets the repo's Actions default be lowered to `read` later without the release silently `startup_failure`-ing.

`merge_group:` is added to `pull-request.yml` now so the merge queue rule can be added after the transfer — the queue's branch fires neither `pull_request` nor `push`, so this trigger has to land first or the queue waits forever on a check that never starts.

## Metadata written for after the transfer

`repository` / `homepage` / `bugs` and the README badges point at `cyberuni/fsa-emitter`, with a patch changeset so the correction actually ships. Without a changeset nothing versions at all — and Phase C's proof is `npm view fsa-emitter version` advancing, not a green run.

Two badges were stale regardless: the `nodejs` workflow badge named a workflow that no longer exists, and the Semantic Release badge is wrong on a repo that has released with changesets for years. The codecov badge was also still pinned to `master`.

## Not in this PR

The npm package name stays `fsa-emitter`. Trusted publishing pins the *repo*, not the scope.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)